### PR TITLE
Fix prompts when updating all packages

### DIFF
--- a/ThinkUpdateU.sh
+++ b/ThinkUpdateU.sh
@@ -36,7 +36,9 @@ update_deb_packages() {
     sudo apt update
     sudo apt full-upgrade -y
     echo "Actualizarea pachetelor DEB a fost finalizată."
-    read -p "Apăsați Enter pentru a continua..."
+    if [ "$1" != "nopause" ]; then
+        read -p "Apăsați Enter pentru a continua..."
+    fi
 }
 
 # Funcție pentru a actualiza pachetele Flatpak
@@ -45,7 +47,9 @@ update_flatpak_packages() {
     echo "Actualizare pachetelor Flatpak..."
     flatpak update -y
     echo "Actualizarea pachetelor Flatpak a fost finalizată."
-    read -p "Apăsați Enter pentru a continua..."
+    if [ "$1" != "nopause" ]; then
+        read -p "Apăsați Enter pentru a continua..."
+    fi
 }
 
 # Funcție pentru a actualiza pachetele Snap
@@ -54,19 +58,22 @@ update_snap_packages() {
     echo "Actualizare pachetelor Snap..."
     sudo snap refresh
     echo "Actualizarea pachetelor Snap a fost finalizată."
-    read -p "Apăsați Enter pentru a continua..."
+    if [ "$1" != "nopause" ]; then
+        read -p "Apăsați Enter pentru a continua..."
+    fi
 }
 
 # Funcție pentru a actualiza toate tipurile de pachete
 update_all_packages() {
-    update_deb_packages
-    update_flatpak_packages
-    update_snap_packages
+    update_deb_packages nopause
+    update_flatpak_packages nopause
+    update_snap_packages nopause
+    read -p "Actualizarea tuturor pachetelor a fost finalizată. Apăsați Enter pentru a continua..."
 }
 
 while true; do
     show_menu
-    case $option in
+    case "$option" in
         1)
             update_deb_packages
             ;;


### PR DESCRIPTION
## Summary
- avoid pausing after each update step
- pause once after all updates
- properly quote the menu option variable

## Testing
- `bash -n ThinkUpdateU.sh`

------
https://chatgpt.com/codex/tasks/task_e_68459f34bfe8832cb1ddaaf48f2e0224